### PR TITLE
Task/add migrate command

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@ lib/
 
 [include]
 flow-typed/
+node_modules/
 
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Version `next`
 
 ### Added
-_No entries_
+- api: Adds a &#x60;migrate()&#x60;-function on the API to migrate files to the latest version
+- cli: New &#x60;migrate&#x60; command that uses the &#x60;migrate()&#x60;-API to simplify updating strangelog
 
 ### Changed
 _No entries_

--- a/changelog/next/2017-07-08T07:49:14.177Z_addition_api.yml
+++ b/changelog/next/2017-07-08T07:49:14.177Z_addition_api.yml
@@ -1,0 +1,4 @@
+dateTime: '2017-07-08T07:49:14.177Z'
+component: api
+kind: addition
+description: Adds a `migrate()`-function on the API to migrate files to the latest version

--- a/changelog/next/2017-07-08T07:49:46.701Z_addition_cli.yml
+++ b/changelog/next/2017-07-08T07:49:46.701Z_addition_cli.yml
@@ -1,0 +1,6 @@
+dateTime: '2017-07-08T07:49:46.701Z'
+component: cli
+kind: addition
+description: >-
+  New `migrate` command that uses the `migrate()`-API to simplify updating
+  strangelog

--- a/src/api/changelogInfo.js
+++ b/src/api/changelogInfo.js
@@ -1,0 +1,28 @@
+// @flow
+
+import { join as joinPath } from 'path';
+
+import { outputFileSync, existsSync, readFileSync } from 'fs-extra';
+import jsYaml from 'js-yaml';
+
+import type { ChangelogInfoType, ConfigType } from '../types';
+
+export function getChangelogInfo(config: ConfigType): ChangelogInfoType {
+  const infoFilePath = joinPath(config.path, 'info.yml');
+
+  return existsSync(infoFilePath)
+    ? jsYaml.safeLoad(readFileSync(infoFilePath))
+    : { version: -1 };
+}
+
+export function saveChangelogInfo(
+  config: ConfigType,
+  newChangelogInfo: ChangelogInfoType
+): void {
+  const infoFilePath = joinPath(config.path, 'info.yml');
+
+  return outputFileSync(
+    infoFilePath,
+    jsYaml.safeDump(newChangelogInfo)
+  );
+}

--- a/src/api/connectChangelog.js
+++ b/src/api/connectChangelog.js
@@ -7,6 +7,8 @@ import bumpNextVersion from './bumpNextVersion';
 import generate from './generate';
 import getChangelogData from './getChangelogData';
 import getPossibleNextVersions from './getPossibleNextVersions';
+import migrate from './migrate';
+import { getChangelogInfo, saveChangelogInfo } from './changelogInfo';
 
 export default function connectChangelog(config: ConfigType): ChangelogAPIType {
   return {
@@ -27,6 +29,15 @@ export default function connectChangelog(config: ConfigType): ChangelogAPIType {
     },
     getComponentsConfig() {
       return config.components;
+    },
+    migrate() {
+      return migrate(config);
+    },
+    getChangelogInfo() {
+      return getChangelogInfo(config);
+    },
+    saveChangelogInfo(newChangelogInfo) {
+      return saveChangelogInfo(config, newChangelogInfo);
     }
   };
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,5 +1,6 @@
 // @flow
 
 import connectChangelog from './connectChangelog';
+import { CURRENT_VERSION } from './migrations';
 
-export { connectChangelog };
+export { connectChangelog, CURRENT_VERSION };

--- a/src/api/migrate.js
+++ b/src/api/migrate.js
@@ -1,0 +1,32 @@
+// @flow
+
+import type {
+  ConfigType,
+  MigrationResultType,
+  MigratorType,
+  ChangelogInfoType
+} from '../types';
+
+import { getChangelogInfo, saveChangelogInfo } from './changelogInfo';
+import migrations from './migrations';
+
+export default function migrate(
+  config: ConfigType
+): MigrationResultType {
+  const oldChangelogInfo: ChangelogInfoType = getChangelogInfo(config);
+
+  migrations
+    .slice(oldChangelogInfo.version)
+    .forEach((migrateNext: MigratorType) => {
+      migrateNext(config);
+    });
+
+  saveChangelogInfo(config, {
+    version: migrations.length
+  });
+
+  return {
+    from: oldChangelogInfo.version,
+    to: migrations.length
+  };
+}

--- a/src/api/migrations/index.js
+++ b/src/api/migrations/index.js
@@ -1,0 +1,19 @@
+// @flow
+
+import { join as joinPath } from 'path';
+
+import { sync as syncGlob } from 'glob';
+import { moveSync } from 'fs-extra';
+
+import type { MigratorType } from '../../types';
+
+const migrations = ([
+  (config) =>
+    syncGlob(joinPath(config.path, '*'))
+      .forEach((versionDirectoryName) =>
+        moveSync(versionDirectoryName, `${versionDirectoryName}.0`))
+]: MigratorType[]);
+
+export default migrations;
+
+export const CURRENT_VERSION = migrations.length;

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -13,29 +13,40 @@ import type {
 import runAdd from './commands/add';
 import runBump from './commands/bump';
 import runGenerate from './commands/generate';
+import runMigrate from './commands/migrate';
 
 export default function cli(args: string[]) {
   yargs(args)
     .command(
       'add',
-      'add a changelog entry',
+      'adds a changelog entry',
       () => {},
       withAPI((changelog) => runAdd(changelog))
     )
     .command(
       'bump',
-      'bump "next" changelog to new version',
+      'bumps "next" changelog to new version',
       () => {},
       withAPI((changelog) => runBump(changelog))
     )
-    .command('generate', 'generate changelog for all versions', (yargs) => {
+    .command(
+      'migrate',
+      'migrates changelog files to latest version after updating strangelog',
+      () => {},
+      withAPI((changelog) => runMigrate(changelog))
+    )
+    .command(
+      'generate',
+      'generates changelog for all versions',
+      (yargs) => {
         yargs.option('outFile', {
           alias: 'f',
           describe: 'name of the changelog file to write',
           // default: 'CHANGELOG.md',
           demandOption: true
         });
-      }, withAPI((changelog, argv: CLIGenerateOptionsType) => runGenerate(changelog, argv))
+      },
+      withAPI((changelog, argv: CLIGenerateOptionsType) => runGenerate(changelog, argv))
     )
     .options({
       directory: {

--- a/src/cli/commands/migrate.js
+++ b/src/cli/commands/migrate.js
@@ -1,0 +1,11 @@
+// @flow
+
+import { type ChangelogAPIType } from '../../types';
+
+export default async function runMigrate(
+  changelog: ChangelogAPIType
+) {
+  const { from, to } = changelog.migrate();
+
+  console.log(`Successfully migrated from version ${from} to version ${to}`);
+}

--- a/src/types.js
+++ b/src/types.js
@@ -1,9 +1,20 @@
 // @flow
 
+export type MigrationResultType = {
+  from: number,
+  to: number
+};
+
 export type ConfigType = {
   path: string,
   components: ComponentsConfigType
 };
+
+export type ChangelogInfoType = {
+  version: number
+};
+
+export type MigratorType = (config: ConfigType) => void
 
 export type ComponentsConfigType = {
   [name: string]: string
@@ -40,7 +51,10 @@ export type ChangelogAPIType = {
   generate: () => string,
   getChangelogData: () => ChangelogType,
   getPossibleNextVersions: () => VersionType[] | null,
-  getComponentsConfig: () => ComponentsConfigType
+  getComponentsConfig: () => ComponentsConfigType,
+  migrate: () => MigrationResultType,
+  getChangelogInfo: () => ChangelogInfoType,
+  saveChangelogInfo: (newChangelogInfo: ChangelogInfoType) => void
 };
 
 export type CLIOptionsType = {

--- a/test/factories/fileSystem.js
+++ b/test/factories/fileSystem.js
@@ -3,5 +3,5 @@
 export function getOwnTestPath(): string {
   const currentNanoSeconds = process.hrtime()[1];
 
-  return `tmpTestChangelog_${currentNanoSeconds}_${Math.random()}`;
+  return `tmpTest/changelog_${currentNanoSeconds}_${Math.random()}`;
 }

--- a/test/factories/testProject.js
+++ b/test/factories/testProject.js
@@ -1,0 +1,40 @@
+// @flow
+
+import { join as joinPath } from 'path';
+
+import { outputFileSync } from 'fs-extra';
+import jsYaml from 'js-yaml';
+
+import { CURRENT_VERSION } from '../../src/api';
+
+import { getOwnTestPath } from './fileSystem';
+
+export function createTestProject(): {
+  rootPath: string,
+  changelogPath: string,
+  infoFilePath: string
+} {
+  const rootPath = getOwnTestPath();
+  const changelogPath = joinPath(rootPath, '/changelog');
+  const infoFilePath = joinPath(changelogPath, '/info.yml');
+
+  outputYAMLSync(joinPath(rootPath, '.strangelogrc'), {
+    path: 'changelog',
+    components: {
+      comp1: 'Comp 1',
+      comp2: 'Comp 2'
+    }
+  });
+
+  outputYAMLSync(infoFilePath, { version: CURRENT_VERSION });
+
+  return {
+    rootPath,
+    changelogPath,
+    infoFilePath
+  };
+}
+
+function outputYAMLSync(path, json) {
+  outputFileSync(path, jsYaml.safeDump(json));
+}

--- a/test/specs/api/migrate.spec.js
+++ b/test/specs/api/migrate.spec.js
@@ -1,0 +1,83 @@
+// @flow
+
+import { join as joinPath } from 'path';
+
+import { removeSync, readFileSync, mkdirsSync, statSync } from 'fs-extra';
+import { safeLoad } from 'js-yaml';
+
+import { connectChangelog, CURRENT_VERSION } from '../../../src/api';
+import { createTestProject } from '../../factories/testProject';
+
+describe('migrate', () => {
+
+  let currentRootPath;
+
+  afterEach(() => {
+    removeSync(currentRootPath);
+  });
+
+  function setup() {
+    const { rootPath, changelogPath, infoFilePath } = createTestProject();
+
+    currentRootPath = rootPath;
+
+    const changelog = connectChangelog({
+      path: changelogPath,
+      components: {
+        comp1: 'Comp 1',
+        comp2: 'Comp 2'
+      }
+    });
+
+    return {
+      rootPath,
+      infoFilePath,
+      changelogPath,
+      changelog
+    };
+  }
+
+  test('only runs migrations beyond current version', () => {
+    const { changelog } = setup();
+
+    expect(changelog.migrate()).toEqual({
+      from: CURRENT_VERSION,
+      to: CURRENT_VERSION
+    });
+  });
+
+  describe('migrations', () => {
+    describe('without an info.yml in the changelog directory', () => {
+      test('writes info.yml with version 0', () => {
+        const { changelog, infoFilePath } = setup();
+
+        removeSync(infoFilePath);
+
+        expect(changelog.migrate()).toEqual({
+          from: -1,
+          to: CURRENT_VERSION
+        });
+        expect(safeLoad(readFileSync(infoFilePath).toString())).toEqual({
+          version: CURRENT_VERSION
+        });
+      });
+    });
+
+    describe('to version 1', () => {
+      test('transforms `x.y` version directory style to SemVer (`x.,y.z`)', () => {
+        const { changelog, changelogPath } = setup();
+        const oldPath = joinPath(changelogPath, '1.0');
+        const newPath = joinPath(changelogPath, '1.0.0');
+
+        mkdirsSync(oldPath);
+        changelog.saveChangelogInfo({ version: 0 });
+
+        changelog.migrate();
+
+        expect(() => statSync(oldPath)).toThrow();
+        expect(() => statSync(newPath)).not.toThrow();
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
High-level changes:
- there is now a `migrate` command on the CLI which is meant to be run on every update of `strangelog` to a new version
- the `migrate` command just uses the `migrate()`-function now exposed as part of the API
- there is now an `info.yml` in the changelog path to store the current migrated `version` of the installation (that file is of course created during migration as well as the very first step)
- `migrate()` simply runs all migrations from the current version to the latest version in sequence
- a _migration version_ is just the index of the migration in the array of migrations