### PR TITLE
Skip incorrect migrations in new strangelog-projects

### DIFF
--- a/src/api/changelogInfo.js
+++ b/src/api/changelogInfo.js
@@ -28,16 +28,26 @@ export function saveChangelogInfo(
   );
 }
 
+// Three cases may occur:
+//   1. info.yml exists already -> we can exit, the project is setup correctly
+//   2. info.yml does not exist and we have no changelog entry files yet -> new project, write
+//      initial config and set migration version to latest since it's implicitly up-to-date
+//   3. info.yml does not exist but we have changelog entry files already -> old project, with
+//      implicit migration version -1 (since info.yml was introduced with the first migration)
 function ensureInitializedProject(config) {
-  const hasEntries = globSync(joinPath(config.path, '**/*')).length > 0;
-
-
   if (existsSync(getInfoFilePath(config))) {
+    // Case 1
     return;
   }
 
+  const hasEntries = globSync(joinPath(config.path, '**/*')).length > 0;
+
   saveChangelogInfo(config, {
-    version: hasEntries ? -1 : CURRENT_VERSION
+    version: hasEntries
+      // Case 3
+      ? -1
+      // Case 2
+      : CURRENT_VERSION
   });
 }
 

--- a/src/api/migrations/1_toFSFriendlyEntryFileName.js
+++ b/src/api/migrations/1_toFSFriendlyEntryFileName.js
@@ -18,11 +18,17 @@ const ENTRY_FILE_PATH_ISO_DATE_MATCHER =
 export default function toSemVerDirectories(config: ConfigType) {
   syncGlob(joinPath(config.path, '*/*.yml'))
     .forEach((oldFileName) => {
+      const dateMatches = oldFileName.match(ENTRY_FILE_PATH_ISO_DATE_MATCHER);
+
+      if (!dateMatches) {
+        return;
+      }
+
       const [
         beforeDatePart,
         datePart,
         afterPart
-      ] = oldFileName.match(ENTRY_FILE_PATH_ISO_DATE_MATCHER).slice(1);
+      ] = dateMatches.slice(1);
 
       moveSync(oldFileName, `${beforeDatePart}${datePart.replace(/:/g, '-')}${afterPart}`);
     });


### PR DESCRIPTION
**Steps to reproduce:**
1. Setup a new strangelog project (this means to just install strangelog
   as a dependency since ther eis no "init"-step)
2. Add an entry (e.g. via `strangelog add`)
3. Run `strangelog migrate`

**Expected:**
See "Migrated from [LATEST] to [LATEST]" (since this is a new project and
there should be nothing to migrate)

**Actual:**
- see "Migrated from -1 to [LATEST]"
- have broken version directory names (`1.0.0` becomes `1.0.0.0`)

**Technical Reason:**
The absence of the `info.yml` is interpreted as a project being on the
migration version `-1` of strangelog (the version before `info.yml` and thus
migrations were introduced). In new projects however, an `info.yml` also does
not exists due to the (intentional) lack of an "init"-command/step.

**Fix:**
Differentiate between
- a project not having an `info.yml` and no entry files yet (assumes a new,
  already "migrated" project)
- a project not having an `info.yml` but some entry files already (assumes
  an old, not yet migrated project)